### PR TITLE
1 implement a hook which can get the selected endpoint on the current page

### DIFF
--- a/src-tauri/src/commands/endpoint_commands.rs
+++ b/src-tauri/src/commands/endpoint_commands.rs
@@ -20,6 +20,17 @@ pub async fn get_all_endpoints(
         .map_err(|e| e.to_string())
 }
 
+#[command]
+pub async fn get_endpoint_by_id(
+    app_handle: AppHandle,
+    id: String,
+) -> Result<Option<Endpoint>, String> {
+    let pool = app_handle.state::<SqlitePool>();
+    EndpointRepository::find_by_id(&pool, &id)
+        .await
+        .map_err(|e| e.to_string())
+}
+
 #[tauri::command]
 pub async fn create_endpoint(
     app_handle: AppHandle,

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -40,6 +40,7 @@ macro_rules! app_commands {
             commands::delete_setting,
             commands::upsert_setting,
             commands::get_all_endpoints,
+            commands::get_endpoint_by_id,
             commands::create_endpoint,
         ]
     };

--- a/src/bridges/endpoint-bridge.ts
+++ b/src/bridges/endpoint-bridge.ts
@@ -19,6 +19,16 @@ export class EndpointBridge {
       throw error
     }
   }
+  static async getEndpointById(id: string): Promise<Endpoint> {
+    try {
+      return await invoke<Endpoint>('get_endpoint_by_id', {
+        id,
+      })
+    } catch (error) {
+      console.error('Failed to get endpoint by ID:', error)
+      throw error
+    }
+  }
   static async createEndpoint(dto: CreateEndpointDto): Promise<Endpoint> {
     try {
       const endpoint = await invoke<Endpoint>('create_endpoint', {

--- a/src/stores/app-sidebar-menu.ts
+++ b/src/stores/app-sidebar-menu.ts
@@ -1,7 +1,7 @@
 import { AppSidebarMenuItemKeys, SettingsKeys } from '@/constants'
 import { SettingsCategories, SettingsValueTypes } from '@/types'
 import { create } from 'zustand'
-import { persist } from 'zustand/middleware'
+import { persist, subscribeWithSelector } from 'zustand/middleware'
 import { createSettingsStorage } from './storages'
 
 interface AppSidebarMenuStoreState {
@@ -15,22 +15,24 @@ interface AppSidebarMenuStoreActions {
 type AppSidebarMenuStore = AppSidebarMenuStoreState & AppSidebarMenuStoreActions
 
 export const useAppSidebarMenuStore = create<AppSidebarMenuStore>()(
-  persist(
-    (set) => ({
-      activeItemKey: AppSidebarMenuItemKeys.ENDPOINT,
-      setActiveItemKey: (key: AppSidebarMenuItemKeys) =>
-        set({ activeItemKey: key }),
-    }),
-    {
-      name: SettingsKeys.UI.SIDEBAR.ACTIVE_ITEM,
-      storage: createSettingsStorage<AppSidebarMenuStoreState>({
-        valueKey: 'activeItemKey',
-        upsertOptions: {
-          value_type: SettingsValueTypes.STRING,
-          category: SettingsCategories.APP_SIDEBAR,
-          description: 'Active item key in the app sidebar menu',
-        },
+  subscribeWithSelector(
+    persist(
+      (set) => ({
+        activeItemKey: AppSidebarMenuItemKeys.ENDPOINT,
+        setActiveItemKey: (key: AppSidebarMenuItemKeys) =>
+          set({ activeItemKey: key }),
       }),
-    }
+      {
+        name: SettingsKeys.UI.SIDEBAR.ACTIVE_ITEM,
+        storage: createSettingsStorage<AppSidebarMenuStoreState>({
+          valueKey: 'activeItemKey',
+          upsertOptions: {
+            value_type: SettingsValueTypes.STRING,
+            category: SettingsCategories.APP_SIDEBAR,
+            description: 'Active item key in the app sidebar menu',
+          },
+        }),
+      }
+    )
   )
 )

--- a/src/stores/endpoint-selected-state.ts
+++ b/src/stores/endpoint-selected-state.ts
@@ -1,7 +1,10 @@
+import { EndpointBridge } from '@/bridges'
 import { AppSidebarMenuItemKeys, SettingsKeys } from '@/constants'
+import { Endpoint } from '@/generated/typeshare-types'
 import { SettingsCategories, SettingsValueTypes } from '@/types'
 import { create } from 'zustand'
 import { persist } from 'zustand/middleware'
+import { useAppSidebarMenuStore } from './app-sidebar-menu'
 import { createSettingsStorage } from './storages'
 
 interface setSelectedEndpointParams {
@@ -11,6 +14,7 @@ interface setSelectedEndpointParams {
 
 interface EndpointSelectedStateStoreState {
   selectedEndpoints: Record<string, string | null> // active menu item key -> endpointId
+  currentPageSelectedEndpoint: Endpoint | null
 }
 
 interface EndpointSelectedStateStoreActions {
@@ -21,18 +25,37 @@ type EndpointStateStore = EndpointSelectedStateStoreState &
 
 export const useEndpointSelectedStateStore = create<EndpointStateStore>()(
   persist(
-    (set) => ({
-      selectedEndpoints: {},
-      setSelectedEndpoint: (params: setSelectedEndpointParams) => {
-        const { menuItem, endpointId } = params
-        set((state) => ({
-          selectedEndpoints: {
-            ...state.selectedEndpoints,
-            [menuItem]: endpointId,
-          },
-        }))
-      },
-    }),
+    (set, get) => {
+      useAppSidebarMenuStore.subscribe(
+        (state) => state.activeItemKey,
+        async (activeItemKey) => {
+          const currentPageSelectedEndpoint =
+            await getCurrentPageSelectedEndpoint({
+              activeItemKey: activeItemKey,
+              selectedEndpoints: get().selectedEndpoints,
+            })
+          set((prevState) => ({
+            ...prevState,
+            currentPageSelectedEndpoint,
+          }))
+        }
+      )
+      return {
+        selectedEndpoints: {},
+        currentPageSelectedEndpoint: null,
+        setSelectedEndpoint: ({
+          menuItem,
+          endpointId,
+        }: setSelectedEndpointParams) => {
+          set((state) => ({
+            selectedEndpoints: {
+              ...state.selectedEndpoints,
+              [menuItem]: endpointId,
+            },
+          }))
+        },
+      }
+    },
     {
       name: SettingsKeys.APP_STATE.SELECTED_ENDPOINT,
       storage: createSettingsStorage<EndpointSelectedStateStoreState>({
@@ -46,3 +69,38 @@ export const useEndpointSelectedStateStore = create<EndpointStateStore>()(
     }
   )
 )
+
+const getCurrentPageSelectedEndpoint = async (params: {
+  activeItemKey: AppSidebarMenuItemKeys
+  selectedEndpoints: Record<string, string | null>
+}) => {
+  const { activeItemKey, selectedEndpoints } = params
+  if (!activeItemKey) return null
+
+  const selectedEndpointId = selectedEndpoints[activeItemKey]
+  // if no endpointId is selected, fetch the first endpoint from the list
+  return selectedEndpointId
+    ? fetchEndpointById(selectedEndpointId)
+    : fetchFallbackEndpoint()
+}
+
+const fetchFallbackEndpoint = async () => {
+  try {
+    const endpoints = await EndpointBridge.listEndpoints({
+      pagination: { page: 1, per_page: 1 },
+    })
+    return endpoints.items[0] || null
+  } catch (error) {
+    console.error('Error fetching fallback endpoint:', error)
+    return null
+  }
+}
+
+const fetchEndpointById = async (endpointId: string) => {
+  try {
+    return await EndpointBridge.getEndpointById(endpointId)
+  } catch (error) {
+    console.error('Error fetching endpoint by ID:', error)
+    return null
+  }
+}


### PR DESCRIPTION
#1 

Get the current page’s active endpoint.
If the endpoint by ID no longer exists, fallback to the first endpoint in the database.