### PR TITLE
Fix theme mode rehydration to ensure correct state

### DIFF
--- a/src/stores/theme-mode.ts
+++ b/src/stores/theme-mode.ts
@@ -74,8 +74,9 @@ export const useThemeModeStore = create<ThemeModeStore>()(
       onRehydrateStorage: () => (state) => {
         setupSystemThemeListener()
         if (state) {
-          const { resolvedThemeMode } = syncThemeModeToDom(state.themeMode)
-          useThemeModeStore.setState({ resolvedThemeMode })
+          const themeMode = state.themeMode || 'system'
+          const { resolvedThemeMode } = syncThemeModeToDom(themeMode)
+          useThemeModeStore.setState({ resolvedThemeMode, themeMode })
         }
       },
     }


### PR DESCRIPTION
Closes:  #10 

This pull request updates the `useThemeModeStore` rehydration logic to handle cases where `themeMode` is undefined and ensures both `resolvedThemeMode` and `themeMode` are properly set in the store.

### Changes to theme mode handling:
* [`src/stores/theme-mode.ts`](diffhunk://#diff-535aedc0d50b0525667afde4ea56ce23336f74f6c7c0b0f71b5677a66a85393bL77-R79): Updated the `onRehydrateStorage` function to default `themeMode` to `'system'` if it is undefined and ensure both `resolvedThemeMode` and `themeMode` are set in the store.