### PR TITLE
Add HTTP client and update GraphQL request handling

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -3184,6 +3184,7 @@ name = "query-box"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "once_cell",
  "reqwest",
  "serde",
  "serde_json",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -32,3 +32,4 @@ uuid = { version = "1.16.0" }
 strum = {version = "0.27" }
 strum_macros = { version = "0.27" }
 anyhow = "1.0.98"
+once_cell = "1.21.3"

--- a/src-tauri/src/commands/graphql_commands.rs
+++ b/src-tauri/src/commands/graphql_commands.rs
@@ -1,7 +1,9 @@
-use reqwest::{Client, Method};
+use reqwest::Method;
 use serde_json::Value;
 use std::collections::HashMap;
 use tauri::command;
+
+use crate::common::http_client::HTTP_CLIENT;
 
 #[derive(serde::Serialize)]
 struct GraphQLRequestBody {
@@ -44,9 +46,8 @@ pub async fn send_graphql_request(
         m => return Err(format!("Unsupported method: {}", m)),
     };
 
-    // Initialize an HTTP client and build the base request with default headers.
     // "Content-Type" and "Accept" are set to "application/json" for GraphQL compatibility.
-    let client = Client::new();
+    let client = &*HTTP_CLIENT;
     let mut request = client
         .request(method.clone(), endpoint)
         .header("Content-Type", "application/json")

--- a/src-tauri/src/common/http_client.rs
+++ b/src-tauri/src/common/http_client.rs
@@ -1,0 +1,10 @@
+use once_cell::sync::Lazy;
+use reqwest::Client;
+use std::time::Duration;
+
+pub static HTTP_CLIENT: Lazy<Client> = Lazy::new(|| {
+    Client::builder()
+        .timeout(Duration::from_secs(30))
+        .build()
+        .expect("Failed to build HTTP client")
+});

--- a/src-tauri/src/common/mod.rs
+++ b/src-tauri/src/common/mod.rs
@@ -1,1 +1,2 @@
+pub mod http_client;
 pub mod http_method;


### PR DESCRIPTION
Closes: #17 

- Introduced a shared HTTP client using `once_cell` for efficient reuse.
- Updated `send_graphql_request` to utilize the new HTTP client.
- Added `once_cell` dependency in Cargo.toml and updated Cargo.lock.
