### PR TITLE
Update GitHub Actions workflow to trigger on release creation

### DIFF
--- a/.github/workflows/publish-to-auto-release.yml
+++ b/.github/workflows/publish-to-auto-release.yml
@@ -1,9 +1,9 @@
 name: 'publish'
 
 on:
-  push:
-    branches:
-      - release
+  release:
+    types:
+      - created
 
 jobs:
   publish-tauri:
@@ -105,9 +105,4 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          tagName: app-v__VERSION__ # the action automatically replaces \_\_VERSION\_\_ with the app version.
-          releaseName: 'App v__VERSION__'
-          releaseBody: 'See the assets to download this version and install.'
-          releaseDraft: true
-          prerelease: false
           args: ${{ matrix.args }}


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow for publishing releases. The changes transition the workflow trigger from `push` events on the `release` branch to `release` events of type `created` and remove unused release-related parameters from the `jobs` configuration.

**Workflow trigger updates:**
* [`.github/workflows/publish-to-auto-release.yml`](diffhunk://#diff-fbd89cd0a5b4e715fa75cfa43a45e2323b4c1761e361206fd82f7a5e583c0986L4-R6): Changed the workflow trigger from `push` events on the `release` branch to `release` events of type `created`.

**Job configuration cleanup:**
* [`.github/workflows/publish-to-auto-release.yml`](diffhunk://#diff-fbd89cd0a5b4e715fa75cfa43a45e2323b4c1761e361206fd82f7a5e583c0986L108-L112): Removed unused parameters such as `tagName`, `releaseName`, `releaseBody`, `releaseDraft`, and `prerelease` from the `jobs` configuration.