### PR TITLE
Remove pnpm workspace configuration file

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,2 +1,0 @@
-onlyBuiltDependencies:
-  - core-js-pure


### PR DESCRIPTION
Closes: #27 

fix https://github.com/zhnd/query-box/pull/24/commits/cd80149606509077f0c61d5a073264fed9dcc1d5

Modified in the previous commit to address the warning shown in the image below.

<img width="734" alt="image" src="https://github.com/user-attachments/assets/19778266-bfcd-4718-ba8e-044e576c20d3" />

But this modification caused the Action to fail to execute: #27 

About ppm approve builds: https://pnpm.io/cli/approve-builds

After analysis, the source of this script is from:

<img width="540" alt="image" src="https://github.com/user-attachments/assets/db9c84f3-c518-4887-bae9-1ab03e069eab" />

During the build process of the action, the related content will not be used, so it can be ignored.During the build action, the webpack dev server will not be started.

Therefore, this file is deleted here.