### PR TITLE
Update predev script to use pnpm for generating types

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "start": " pnpm turbo generate-types && pnpm tauri dev",
     "generate-types": "node scripts/generate.js",
-    "predev": "npm run generate-types",
+    "predev": "pnpm turbo generate-types",
     "dev": "cross-env NODE_ENV=development webpack serve --config webpack/config.dev.js",
     "build": "cross-env NODE_ENV=production webpack --config webpack/config.prod.js",
     "tauri": "tauri",


### PR DESCRIPTION
Closes: #29 

fixed `pnpm tauri dev` allways miss turbo cache of generate types task.

before fix:

<img width="1039" alt="image" src="https://github.com/user-attachments/assets/cfffe24c-d911-4e6d-9034-b2b93d5961af" />

No file changes, cache will be hit, after:

<img width="818" alt="image" src="https://github.com/user-attachments/assets/fc3b1bd4-8d79-41e2-a0e3-32f1911b4185" />


This pull request updates the `predev` script in the `package.json` file to align with the use of `pnpm` for task execution, ensuring consistency across the project.

* **Consistency in task execution**:
  - Updated the `predev` script to use `pnpm turbo generate-types` instead of `npm run generate-types`, aligning it with the project's use of `pnpm` for task execution. (`package.json`, [package.jsonL8-R8](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L8-R8))