### PR TITLE
delete all request history

### DIFF
--- a/src/query-box-app/explorer/history-tabs/use-service.ts
+++ b/src/query-box-app/explorer/history-tabs/use-service.ts
@@ -90,8 +90,8 @@ export const useRequestHistoryTabsService = () => {
     await RequestHistoryBridge.deleteRequestHistory({
       endpoint_id: selectedEndpoint?.id ?? '',
     })
-    setRequestHistories([])
-    await handleAddRequestHistory()
+    const newRequestHistory = await createEmptyRequestHistory()
+    setRequestHistories([newRequestHistory])
   }
 
   useEffect(() => {


### PR DESCRIPTION
Closes: #31 

opt delete all request history

This pull request updates the behavior of the `useRequestHistoryTabsService` function to improve how request histories are managed after deletion. Specifically, it ensures that a new empty request history is created and set immediately after deletion instead of clearing the list and adding a new history separately.

Key change:

* [`src/query-box-app/explorer/history-tabs/use-service.ts`](diffhunk://#diff-70fef7e72b098b749dc1f266bfb86a2f74ea16545812f098a5157fe296ea68e8L93-R94): Replaced the logic in the `deleteRequestHistory` function to create and set a new empty request history directly after deletion, streamlining the process.