### PR TITLE
update monaco editor schema when endpoint url change

### DIFF
--- a/src/components/query-editor/utils.ts
+++ b/src/components/query-editor/utils.ts
@@ -1,0 +1,79 @@
+import { createGraphiQLFetcher } from '@graphiql/toolkit'
+import {
+  buildClientSchema,
+  getIntrospectionQuery,
+  GraphQLSchema,
+  IntrospectionQuery,
+} from 'graphql'
+import { Uri } from 'monaco-editor'
+import { MonacoGraphQLAPI } from 'monaco-graphql/esm/api.js'
+import { initializeMode } from 'monaco-graphql/initializeMode'
+
+export async function updateGraphQLSchema(params: {
+  endpointUrl: string
+  monacoGraphQLApi: MonacoGraphQLAPI
+}): Promise<void> {
+  const { endpointUrl, monacoGraphQLApi } = params
+  const schema = await getGraphQLSchema({ endpointUrl })
+
+  monacoGraphQLApi.setSchemaConfig([
+    {
+      schema,
+      uri: 'schema.graphql',
+    },
+  ])
+}
+
+export async function setupGraphQLSchemaInMonaco(params: {
+  endpointUrl: string
+}): Promise<MonacoGraphQLAPI> {
+  const { endpointUrl } = params
+  const schema = await getGraphQLSchema({ endpointUrl })
+
+  const monacoGraphQLApi = initializeMode({
+    diagnosticSettings: {
+      validateVariablesJSON: {
+        [Uri.file('operation.graphql').toString()]: [
+          Uri.file('variables.json').toString(),
+        ],
+      },
+      jsonDiagnosticSettings: {
+        validate: true,
+        schemaValidation: 'error',
+        allowComments: true,
+        trailingCommas: 'ignore',
+      },
+    },
+    schemas: [
+      {
+        schema,
+        uri: 'schema.graphql',
+      },
+    ],
+  })
+
+  return monacoGraphQLApi
+}
+
+export async function getGraphQLSchema(params: {
+  endpointUrl: string
+}): Promise<GraphQLSchema> {
+  const { endpointUrl } = params
+  const fetcher = createGraphiQLFetcher({
+    url: endpointUrl,
+  })
+
+  const data = await fetcher({
+    query: getIntrospectionQuery(),
+    operationName: 'IntrospectionQuery',
+  })
+  const introspectionJSON =
+    'data' in data && (data.data as unknown as IntrospectionQuery)
+
+  if (!introspectionJSON) {
+    throw new Error(
+      'Failed to fetch GraphQL introspection schema: subscriptions and HTTP multipart are not supported. Please ensure the endpoint supports standard introspection queries.'
+    )
+  }
+  return buildClientSchema(introspectionJSON)
+}


### PR DESCRIPTION
Closes: #36 
This pull request refactors the GraphQL integration in the `QueryEditor` component by modularizing schema management and simplifying the initialization process. The changes improve maintainability and reusability by moving schema-related logic into utility functions and replacing inline code with cleaner abstractions.

### Refactoring for GraphQL Schema Management:

* **Modularized GraphQL schema setup and updates**: Moved the logic for fetching and setting up GraphQL schemas from `use-service.ts` to new utility functions `setupGraphQLSchemaInMonaco`, `updateGraphQLSchema`, and `getSchema` in `utils.ts`. This reduces duplication and improves code clarity.

* **Replaced `initializeMode` with `setupGraphQLSchemaInMonaco`**: Replaced the inline usage of `initializeMode` in `useService` with the new `setupGraphQLSchemaInMonaco` utility function, streamlining the initialization of GraphQL mode with the endpoint URL.

### Code Cleanup and Simplification:

* **Removed redundant imports and methods**: Removed unused imports and the now-obsolete `getSchema` function from `use-service.ts`, as its functionality has been moved to `utils.ts`. [[1]](diffhunk://#diff-6e2b58fb93f98d11a110e3d8ae1b71365c365340d8a919a477da0445985fe6a8L3-R11) [[2]](diffhunk://#diff-6e2b58fb93f98d11a110e3d8ae1b71365c365340d8a919a477da0445985fe6a8L158-R149)

* **Introduced `monacoGraphQLApiRef`**: Added a `monacoGraphQLApiRef` to manage the `MonacoGraphQLAPI` instance, improving the state management of the GraphQL editor integration.