### PR TITLE
Enhance GraphQL Explorer: Add "Go to Definition" functionality

### DIFF
--- a/src/components/query-editor/use-service.ts
+++ b/src/components/query-editor/use-service.ts
@@ -9,7 +9,11 @@ import parserGraphql from 'prettier/parser-graphql'
 import prettier from 'prettier/standalone'
 import { useEffect, useRef } from 'react'
 import { QUERY_EXAMPLE } from './constants'
-import { setupGraphQLSchemaInMonaco, updateGraphQLSchema } from './utils'
+import {
+  handleGoToGraphqlFieldDefinition,
+  setupGraphQLSchemaInMonaco,
+  updateGraphQLSchema,
+} from './utils'
 
 export interface QueryEditorProps {
   initialValue?: string
@@ -17,10 +21,11 @@ export interface QueryEditorProps {
   onChange?: (value: string) => void
   className?: string
   schema: GraphQLSchema | null
+  onViewDefinition?: (fieldName: string) => void
 }
 
 export function useService(props: QueryEditorProps) {
-  const { onChange, initialValue, value, schema } = props
+  const { onChange, initialValue, value, schema, onViewDefinition } = props
 
   const editorContainerElementRef = useRef<HTMLDivElement>(null)
   const editorInstanceRef = useRef<monaco.editor.IStandaloneCodeEditor | null>(
@@ -32,7 +37,7 @@ export function useService(props: QueryEditorProps) {
   const { resolvedThemeMode } = useThemeModeStore()
 
   const init = async () => {
-    if (editorInstanceRef.current || initializingRef.current) return
+    if (editorInstanceRef.current || initializingRef.current || !schema) return
     initializingRef.current = true
 
     monaco.editor.defineTheme('github-light', githubLightTheme)
@@ -100,6 +105,46 @@ export function useService(props: QueryEditorProps) {
       },
     })
 
+    // add Go to Definition action
+    editorInstance.addAction({
+      id: 'graphql-provide-definition',
+      label: 'Go to Definition F12',
+      contextMenuGroupId: 'navigation',
+      contextMenuOrder: 1,
+      run: (editor) => {
+        handleGoToGraphqlFieldDefinition({ schema, editor, onViewDefinition })
+      },
+    })
+
+    // register custom Go to Definition command
+    // This allows users to use F12 on field names to navigate to their definitions
+    editorInstance.addCommand(monaco.KeyCode.F12, () => {
+      handleGoToGraphqlFieldDefinition({
+        schema,
+        editor: editorInstance,
+        onViewDefinition,
+      })
+    })
+
+    // Handle mouse down events to go to GraphQL field definition
+    // when Ctrl/Cmd key is pressed
+    // and the target is a text content
+    // This allows users to click on field names to navigate to their definitions
+    editorInstance.onMouseDown((e) => {
+      const { event, target } = e
+      if (
+        (event.ctrlKey || event.metaKey) &&
+        target.type === monaco.editor.MouseTargetType.CONTENT_TEXT
+      ) {
+        handleGoToGraphqlFieldDefinition({
+          schema,
+          editor: editorInstance,
+          position: target.position,
+          onViewDefinition,
+        })
+      }
+    })
+
     // Initialize GraphQL mode with the endpoint URL
     monacoGraphQLApiRef.current = await setupGraphQLSchemaInMonaco({
       schema,
@@ -118,7 +163,7 @@ export function useService(props: QueryEditorProps) {
         initializingRef.current = false
       }
     }
-  }, [])
+  }, [schema])
 
   useEffect(() => {
     editorInstanceRef.current?.updateOptions({

--- a/src/components/query-editor/utils.ts
+++ b/src/components/query-editor/utils.ts
@@ -2,10 +2,15 @@ import { createGraphiQLFetcher } from '@graphiql/toolkit'
 import {
   buildClientSchema,
   getIntrospectionQuery,
+  getNamedType,
   GraphQLSchema,
   IntrospectionQuery,
+  parse,
+  TypeInfo,
+  visit,
+  visitWithTypeInfo,
 } from 'graphql'
-import { Uri } from 'monaco-editor'
+import { editor, Position, Uri } from 'monaco-editor'
 import { MonacoGraphQLAPI } from 'monaco-graphql/esm/api.js'
 import { initializeMode } from 'monaco-graphql/initializeMode'
 
@@ -76,4 +81,67 @@ export async function getGraphQLSchema(params: {
     )
   }
   return buildClientSchema(introspectionJSON)
+}
+
+function getFieldTypeByASTAnalysis({
+  code,
+  position,
+  schema,
+  word,
+}: {
+  code: string
+  position: Position
+  schema: GraphQLSchema
+  word: editor.IWordAtPosition
+}) {
+  const ast = parse(code)
+  const typeInfo = new TypeInfo(schema)
+
+  let matchedType: string | null = null
+
+  visit(
+    ast,
+    visitWithTypeInfo(typeInfo, {
+      Field(node) {
+        const startToken = node.loc?.startToken
+
+        if (!startToken || node.name.value !== word.word) return
+
+        const sameLine = startToken.line === position.lineNumber
+        const column = position.column
+        const hit =
+          column >= startToken.column &&
+          column <= startToken.column + (startToken.value?.length || 1)
+
+        if (sameLine && hit) {
+          const fieldType = getNamedType(typeInfo.getType())
+          matchedType = fieldType?.toString() ?? null
+        }
+      },
+    })
+  )
+
+  return matchedType
+}
+
+export function handleGoToGraphqlFieldDefinition(params: {
+  editor: editor.ICodeEditor
+  schema: GraphQLSchema | null
+  onViewDefinition?: (fieldName: string) => void
+  position?: Position
+}) {
+  const { schema, editor, position, onViewDefinition } = params
+  const currentPosition = position || editor.getPosition()
+  const model = editor.getModel()
+  if (!currentPosition || !model || !schema) return
+  const word = model.getWordAtPosition(currentPosition)
+  if (!word) return
+
+  const fieldType = getFieldTypeByASTAnalysis({
+    schema,
+    code: model.getValue(),
+    position: currentPosition,
+    word,
+  })
+  onViewDefinition?.(fieldType ?? '')
 }

--- a/src/query-box-app/explorer/documentation/index.tsx
+++ b/src/query-box-app/explorer/documentation/index.tsx
@@ -3,7 +3,11 @@ import { Button } from '@/components/ui/button'
 import { Separator } from '@/components/ui/separator'
 import { ChevronRight, FileText, Hash, Info } from 'lucide-react'
 import { useService } from './use-service'
-import { CurrentTypeFields, DocumentationField } from './utils'
+import {
+  BreadcrumbPathType,
+  CurrentTypeFields,
+  DocumentationField,
+} from './utils'
 
 export function Documentation() {
   const {
@@ -52,19 +56,19 @@ const Breadcrumb = ({
   path,
   onNavigate,
 }: {
-  path: string[]
+  path: BreadcrumbPathType[]
   onNavigate: (index: number) => void
 }) => (
   <div className="flex items-center gap-1 flex-wrap">
-    {path.map((typeName, idx) => (
-      <div key={typeName} className="flex items-center gap-1">
+    {path.map((breadcrumb, idx) => (
+      <div key={breadcrumb.id} className="flex items-center gap-1">
         <Button
           variant="ghost"
           size="sm"
           className="h-7 px-2 text-xs hover:bg-accent"
           onClick={() => onNavigate(idx)}
         >
-          {typeName}
+          {breadcrumb.name}
         </Button>
         {idx < path.length - 1 && (
           <ChevronRight className="h-3 w-3 text-muted-foreground" />

--- a/src/query-box-app/explorer/documentation/use-service.ts
+++ b/src/query-box-app/explorer/documentation/use-service.ts
@@ -1,17 +1,45 @@
+import { useGraphQLExplorerPageStore } from '@/stores'
 import { usePageGraphQLSchemaStore } from '@/stores/page-graphql-schema-state'
-import { useState } from 'react'
-import { getCurrentTypeFields, isValidObjectType } from './utils'
+import { nanoid } from 'nanoid'
+import { useEffect, useState } from 'react'
+import {
+  BreadcrumbPathType,
+  DEFAULT_PATH,
+  getCurrentTypeFields,
+  isValidObjectType,
+} from './utils'
 
 export function useService() {
-  const schema = usePageGraphQLSchemaStore((state) => state.schema)
-  const [path, setPath] = useState<string[]>(['Root'])
+  const [path, setPath] = useState<BreadcrumbPathType[]>([DEFAULT_PATH])
 
-  const currentTypeName = path[path.length - 1]
+  const schema = usePageGraphQLSchemaStore((state) => state.schema)
+  const viewGraphQLDefinitionFieldType = useGraphQLExplorerPageStore(
+    (state) => state.viewGraphQLDefinitionFieldType
+  )
+
+  useEffect(() => {
+    if (!viewGraphQLDefinitionFieldType) return
+    setPath([
+      DEFAULT_PATH,
+      {
+        name: viewGraphQLDefinitionFieldType,
+        id: nanoid(),
+      },
+    ])
+  }, [viewGraphQLDefinitionFieldType])
+
+  const currentTypeName = path[path.length - 1].name
   const currentTypeFields = getCurrentTypeFields(schema, currentTypeName)
 
   const navigateToType = (typeName: string) => {
     if (isValidObjectType(schema, typeName)) {
-      setPath([...path, typeName])
+      setPath([
+        ...path,
+        {
+          name: typeName,
+          id: nanoid(),
+        },
+      ])
     }
   }
 

--- a/src/query-box-app/explorer/documentation/utils.ts
+++ b/src/query-box-app/explorer/documentation/utils.ts
@@ -6,6 +6,17 @@ import {
   isNonNullType,
   isObjectType,
 } from 'graphql'
+import { nanoid } from 'nanoid'
+
+export interface BreadcrumbPathType {
+  name: string
+  id: string
+}
+
+export const DEFAULT_PATH: BreadcrumbPathType = {
+  name: 'Root',
+  id: nanoid(),
+}
 
 export function unwrapType(type: GraphQLType): GraphQLNamedType {
   while (isNonNullType(type) || isListType(type)) {

--- a/src/query-box-app/explorer/request/index.tsx
+++ b/src/query-box-app/explorer/request/index.tsx
@@ -31,6 +31,7 @@ export function Request() {
         onChange={service.handleQueryUpdate}
         initialValue={service.activeRequestHistory.query ?? ''}
         value={service.activeRequestHistory.query ?? ''}
+        onViewDefinition={service.handleGoToGraphqlFieldDefinition}
       />
     </div>
   )

--- a/src/query-box-app/explorer/request/use-service.ts
+++ b/src/query-box-app/explorer/request/use-service.ts
@@ -21,6 +21,10 @@ export const useRequestService = () => {
 
   const setResponse = useGraphQLExplorerPageStore((state) => state.setResponse)
 
+  const setViewGraphQLDefinitionFieldType = useGraphQLExplorerPageStore(
+    (state) => state.setViewGraphQLDefinitionFieldType
+  )
+
   // Get the currently selected endpoint for the current page
   // This is used to send the GraphQL request
   // and to fetch the schema for the current endpoint
@@ -83,6 +87,11 @@ export const useRequestService = () => {
     })
   }
 
+  const handleGoToGraphqlFieldDefinition = (field: string) => {
+    if (!field) return
+    setViewGraphQLDefinitionFieldType(field)
+  }
+
   return {
     schema,
     currentPageSelectedEndpoint,
@@ -90,5 +99,6 @@ export const useRequestService = () => {
     activeRequestHistory,
     handleSendRequest,
     handleQueryUpdate,
+    handleGoToGraphqlFieldDefinition,
   }
 }

--- a/src/stores/graphql-explorer-page-state.ts
+++ b/src/stores/graphql-explorer-page-state.ts
@@ -5,12 +5,14 @@ interface GraphQLExplorerPageState {
   response: string
   requestHistories: RequestHistory[]
   activeRequestHistory: RequestHistory | null
+  viewGraphQLDefinitionFieldType: string | null
 }
 
 interface GraphQLExplorerPageActions {
   setResponse: (response: string) => void
   setRequestHistories: (histories: RequestHistory[]) => void
   setActiveRequestHistory: (requestHistory: RequestHistory | null) => void
+  setViewGraphQLDefinitionFieldType: (field: string | null) => void
 }
 type GraphQLExplorerPageStore = GraphQLExplorerPageState &
   GraphQLExplorerPageActions
@@ -20,10 +22,13 @@ export const useGraphQLExplorerPageStore = create<GraphQLExplorerPageStore>()(
     requestHistories: [],
     activeRequestHistory: null,
     response: '',
+    viewGraphQLDefinitionFieldType: null,
     setResponse: (response) => set(() => ({ response })),
     setRequestHistories: (histories) =>
       set(() => ({ requestHistories: histories })),
     setActiveRequestHistory: (requestHistory) =>
       set(() => ({ activeRequestHistory: requestHistory })),
+    setViewGraphQLDefinitionFieldType: (field) =>
+      set(() => ({ viewGraphQLDefinitionFieldType: field })),
   })
 )


### PR DESCRIPTION
Closes: #41 

This pull request introduces enhancements to the GraphQL query editor and explorer, focusing on adding "Go to Definition" functionality and improving breadcrumb navigation in the documentation explorer. The changes include new methods for navigating GraphQL field definitions, updates to the breadcrumb system, and modifications to the state management for handling field definitions.

### Enhancements to GraphQL Query Editor:

* Added "Go to Definition" functionality in the query editor, allowing users to navigate to GraphQL field definitions using F12, context menu actions, or mouse clicks with Ctrl/Cmd key pressed. (`src/components/query-editor/use-service.ts`, [src/components/query-editor/use-service.tsR108-R147](diffhunk://#diff-6e2b58fb93f98d11a110e3d8ae1b71365c365340d8a919a477da0445985fe6a8R108-R147))
* Introduced `handleGoToGraphqlFieldDefinition` method for analyzing GraphQL AST and determining field types based on editor position and schema. (`src/components/query-editor/utils.ts`, [src/components/query-editor/utils.tsR85-R147](diffhunk://#diff-ada906cba7cd5a172555333dd706249c458b7196b1252d32c862982f99c7f107R85-R147))
* Updated the `useService` hook to include the `onViewDefinition` prop for handling field definition navigation. (`src/components/query-editor/use-service.ts`, [src/components/query-editor/use-service.tsL12-R28](diffhunk://#diff-6e2b58fb93f98d11a110e3d8ae1b71365c365340d8a919a477da0445985fe6a8L12-R28))

### Improvements to Documentation Explorer:

* Enhanced breadcrumb navigation by introducing a `BreadcrumbPathType` interface with unique IDs for each breadcrumb and updating the `path` structure to use this type. (`src/query-box-app/explorer/documentation/utils.ts`, [src/query-box-app/explorer/documentation/utils.tsR9-R19](diffhunk://#diff-0871e4d103060b803b52df153db31e1ad9831d970105741038a074369948407eR9-R19))
* Modified the `useService` hook in the documentation explorer to update breadcrumbs dynamically when navigating to GraphQL field definitions. (`src/query-box-app/explorer/documentation/use-service.ts`, [src/query-box-app/explorer/documentation/use-service.tsR1-R42](diffhunk://#diff-e8faa57ea160b086c0b815c0b9554d400af702bb786caf59e8a038c41330cb11R1-R42))

### State Management Updates:

* Added `viewGraphqlDefinitionFieldType` to the GraphQL Explorer page state for tracking the currently viewed GraphQL field type. (`src/stores/graphql-explorer-page-state.ts`, [[1]](diffhunk://#diff-4dc5c01e24d77bc3ee3bda1d75be35b89bc8abddd2bf87c2c6cbfb7784e0ba5eR8-R15) [[2]](diffhunk://#diff-4dc5c01e24d77bc3ee3bda1d75be35b89bc8abddd2bf87c2c6cbfb7784e0ba5eR25-R32)
* Incorporated `setViewGraphqlDefinitionFieldType` action into the request service to handle field definition navigation. (`src/query-box-app/explorer/request/use-service.ts`, [src/query-box-app/explorer/request/use-service.tsR90-R102](diffhunk://#diff-8f773a7477963be99781b7964c0cec5694b6dec9d0010fee5a54f491fd312367R90-R102))

These changes collectively improve the user experience for navigating and exploring GraphQL schemas, making it easier to interact with field definitions and understand their relationships.