### PR TITLE
Enhance documentation rendering: Introduce ParsedDescription component for formatted descriptions

### DIFF
--- a/src/query-box-app/explorer/documentation/index.tsx
+++ b/src/query-box-app/explorer/documentation/index.tsx
@@ -2,6 +2,7 @@ import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { ChevronRight, Code2, FileText, Zap } from 'lucide-react'
+import { useMemo } from 'react'
 import { useService } from './use-service'
 import {
   BreadcrumbPathType,
@@ -157,7 +158,7 @@ const TypeContent = (props: {
         </div>
         {fields.description && (
           <p className="text-sm text-muted-foreground leading-relaxed pl-10">
-            {fields.description}
+            <ParsedDescription text={fields.description} />
           </p>
         )}
       </div>
@@ -240,3 +241,23 @@ const EmptyState = ({ typeName }: { typeName: string }) => (
     </div>
   </div>
 )
+
+const ParsedDescription = (props: { text: string }) => {
+  const { text } = props
+  const parts = useMemo(() => text.split(/(`[^`]+`)/g), [text])
+
+  return parts.map((part, index) => {
+    if (part.startsWith('`') && part.endsWith('`')) {
+      const code = part.slice(1, -1)
+      return (
+        <code
+          key={index}
+          className="relative rounded bg-muted px-[0.3rem] py-[0.2rem] font-mono text-sm font-semibold"
+        >
+          {code}
+        </code>
+      )
+    }
+    return <span key={index}>{part}</span>
+  })
+}


### PR DESCRIPTION
Closes: #45 

This pull request introduces a new `ParsedDescription` component to improve the rendering of descriptions in the documentation explorer. The key change replaces plain text descriptions with parsed content that highlights inline code blocks using a styled `<code>` element.

### Enhancements to description rendering:

* [`src/query-box-app/explorer/documentation/index.tsx`](diffhunk://#diff-94d61b9988b5a6c8fa8b088580f7b47bed2c2d6c921913a09c290a252c17e24dL160-R160): Updated the `TypeContent` component to use the new `ParsedDescription` component for rendering `fields.description`, enabling inline code blocks to be styled distinctly.
* [`src/query-box-app/explorer/documentation/index.tsx`](diffhunk://#diff-94d61b9988b5a6c8fa8b088580f7b47bed2c2d6c921913a09c290a252c17e24dR243-R262): Added the `ParsedDescription` component, which splits text into parts, identifies inline code blocks, and wraps them in styled `<code>` elements for improved readability.