### PR TITLE
parse and show field NonNull and list property

### DIFF
--- a/src/query-box-app/explorer/documentation/components/field-item/index.tsx
+++ b/src/query-box-app/explorer/documentation/components/field-item/index.tsx
@@ -10,13 +10,13 @@ export function FieldItem(props: {
   return (
     <div
       className="group relative flex items-center justify-between py-2.5 px-3 rounded border border-border bg-card transition-all duration-150 hover:bg-accent hover:border-accent-foreground/20 cursor-pointer active:scale-[0.98]"
-      onClick={() => onNavigate(field.type?.name ?? '')}
+      onClick={() => onNavigate(field.type?.namedType.name ?? '')}
       role="button"
       tabIndex={0}
       onKeyDown={(e) => {
         if (e.key === 'Enter' || e.key === ' ') {
           e.preventDefault()
-          onNavigate(field.type?.name ?? '')
+          onNavigate(field.type?.namedType.name ?? '')
         }
       }}
     >
@@ -32,9 +32,9 @@ export function FieldItem(props: {
           <Badge
             variant="secondary"
             className="text-xs font-mono bg-muted/60 hover:bg-muted/80 transition-colors border-0 px-1.5 py-0.5 flex-shrink-0 max-w-[50%]"
-            title={field.type?.name ?? ''}
+            title={field.type?.displayName ?? ''}
           >
-            <span className="truncate">{field.type?.name ?? ''}</span>
+            <span className="truncate">{field.type?.displayName ?? ''}</span>
           </Badge>
         </div>
       </div>


### PR DESCRIPTION
Closes: #51 

This pull request refactors how GraphQL types are handled in the query box explorer by introducing a new `ParsedTypeInfo` structure. This change enhances type parsing, improves clarity, and ensures consistent handling of type metadata across the codebase. The most significant updates include replacing the `unwrapType` function with the new `parseTypeInfo` function and updating all references to use the new structure.

### Refactoring of GraphQL type handling:

* Replaced the `unwrapType` function with a new `parseTypeInfo` function that provides detailed metadata about GraphQL types, including `namedType`, `isNonNull`, `isList`, `isNonNullList`, and `displayName`. This change ensures more robust and comprehensive type parsing. (`src/query-box-app/explorer/documentation/utils.ts`, [src/query-box-app/explorer/documentation/utils.tsL24-R79](diffhunk://#diff-0871e4d103060b803b52df153db31e1ad9831d970105741038a074369948407eL24-R79))

* Updated the `DocumentationField` interface to use the new `ParsedTypeInfo` type instead of `GraphQLNamedType` for the `type` field. This allows all fields to leverage the enhanced type metadata. (`src/query-box-app/explorer/documentation/utils.ts`, [src/query-box-app/explorer/documentation/utils.tsL24-R79](diffhunk://#diff-0871e4d103060b803b52df153db31e1ad9831d970105741038a074369948407eL24-R79))

### Updates to components using type metadata:

* Modified the `onClick` and `onKeyDown` handlers in the `FieldItem` component to use `field.type?.namedType.name` instead of `field.type?.name`, aligning with the new `ParsedTypeInfo` structure. (`src/query-box-app/explorer/documentation/components/field-item/index.tsx`, [src/query-box-app/explorer/documentation/components/field-item/index.tsxL13-R19](diffhunk://#diff-394a9dfa731d0867d36d3562934a686d6eeaf0b5aed7763e6ea14c9b992f33eaL13-R19))

* Updated the `Badge` component in `FieldItem` to display the `displayName` property from `ParsedTypeInfo` instead of `name`, ensuring that type modifiers like `!` and `[]` are reflected in the UI. (`src/query-box-app/explorer/documentation/components/field-item/index.tsx`, [src/query-box-app/explorer/documentation/components/field-item/index.tsxL35-R37](diffhunk://#diff-394a9dfa731d0867d36d3562934a686d6eeaf0b5aed7763e6ea14c9b992f33eaL35-R37))

### Internal utility updates:

* Replaced calls to `unwrapType` with `parseTypeInfo` in the `getAllSubFields` function, ensuring consistent use of the new type parsing logic. (`src/query-box-app/explorer/documentation/utils.ts`, [src/query-box-app/explorer/documentation/utils.tsL50-R95](diffhunk://#diff-0871e4d103060b803b52df153db31e1ad9831d970105741038a074369948407eL50-R95))