### PR TITLE
show graphql request headers

### DIFF
--- a/src-tauri/typeshare.toml
+++ b/src-tauri/typeshare.toml
@@ -2,3 +2,4 @@
 "DateTime" = "string"
 "Uuid" = "string"
 "Json" = "string"
+"u128" = "number"

--- a/src/bridges/graphql-bridge.ts
+++ b/src/bridges/graphql-bridge.ts
@@ -1,9 +1,10 @@
+import { GraphQLResponse } from '@/generated/typeshare-types'
 import { invoke } from '@tauri-apps/api/core'
 
 export class GraphQLBridge {
   static async send_graphql_request(data: { endpoint: string; query: string }) {
     try {
-      return await invoke<string>('send_graphql_request', data)
+      return await invoke<GraphQLResponse>('send_graphql_request', data)
     } catch (error) {
       console.error('Failed to send GraphQL request:', error)
       throw error

--- a/src/components/response-viewer/index.tsx
+++ b/src/components/response-viewer/index.tsx
@@ -48,9 +48,9 @@ export function ResponseViewer(props: ResponseViewerProps) {
             <p>Please send a network request.</p>
           </div>
         ) : service.activeView === ResponseViewType.BODY ? (
-          <JsonViewer value={data} />
+          <JsonViewer value={data.body} />
         ) : (
-          <JsonViewer value={data} />
+          <JsonViewer value={JSON.stringify(data.headers)} />
         )}
       </div>
     </div>

--- a/src/components/response-viewer/use-service.ts
+++ b/src/components/response-viewer/use-service.ts
@@ -1,8 +1,9 @@
+import { GraphQLResponse } from '@/generated/typeshare-types'
 import { useState } from 'react'
 import { ResponseViewType } from './constants'
 
 export interface ResponseViewerProps {
-  data?: string
+  data: GraphQLResponse | null
 }
 
 export const useResponseViewerService = () => {

--- a/src/stores/graphql-explorer-page-state.ts
+++ b/src/stores/graphql-explorer-page-state.ts
@@ -1,15 +1,15 @@
-import { RequestHistory } from '@/generated/typeshare-types'
+import { GraphQLResponse, RequestHistory } from '@/generated/typeshare-types'
 import { create } from 'zustand'
 
 interface GraphQLExplorerPageState {
-  response: string
+  response: GraphQLResponse | null
   requestHistories: RequestHistory[]
   activeRequestHistory: RequestHistory | null
   viewGraphQLDefinitionFieldType: string | null
 }
 
 interface GraphQLExplorerPageActions {
-  setResponse: (response: string) => void
+  setResponse: (response: GraphQLResponse | null) => void
   setRequestHistories: (histories: RequestHistory[]) => void
   setActiveRequestHistory: (requestHistory: RequestHistory | null) => void
   setViewGraphQLDefinitionFieldType: (field: string | null) => void
@@ -21,7 +21,7 @@ export const useGraphQLExplorerPageStore = create<GraphQLExplorerPageStore>()(
   (set) => ({
     requestHistories: [],
     activeRequestHistory: null,
-    response: '',
+    response: null,
     viewGraphQLDefinitionFieldType: null,
     setResponse: (response) => set(() => ({ response })),
     setRequestHistories: (histories) =>


### PR DESCRIPTION
Closes: #54 

This pull request introduces a structured `GraphQLResponse` type to standardize the handling of GraphQL responses, including metadata like headers, status code, and request duration. It also updates the frontend and backend code to accommodate this new response structure. Below are the most important changes grouped by theme:

### Backend Enhancements:
* Added a new `GraphQLResponse` struct in `src-tauri/src/commands/graphql_commands.rs` to encapsulate response data, including the body, headers, status code, and request duration. This struct is marked with `#[typeshare]` for type sharing between Rust and TypeScript.
* Updated the `send_graphql_request` function to return `GraphQLResponse` instead of a plain string, and added logic to measure request duration, extract headers, and include the HTTP status code. [[1]](diffhunk://#diff-e9a31aa6d7836f128408b9f97e6246d8ed0b405d0d20df07ed057559dab5cc6cR83-R84) [[2]](diffhunk://#diff-e9a31aa6d7836f128408b9f97e6246d8ed0b405d0d20df07ed057559dab5cc6cR105-R124)
* Added a mapping for `u128` to `number` in `src-tauri/typeshare.toml` to support the `duration_ms` field in `GraphQLResponse`.

### Frontend Updates:
* Updated the `GraphQLBridge` class in `src/bridges/graphql-bridge.ts` to use the new `GraphQLResponse` type when invoking the `send_graphql_request` command.
* Modified the `ResponseViewer` component in `src/components/response-viewer/index.tsx` to display the `body` and `headers` fields of `GraphQLResponse` separately, instead of treating the response as a plain string.
* Updated the `ResponseViewerProps` interface in `src/components/response-viewer/use-service.ts` to use `GraphQLResponse | null` instead of a string for the `data` property.

### State Management Adjustments:
* Updated the `response` property in `GraphQLExplorerPageState` within `src/stores/graphql-explorer-page-state.ts` to use `GraphQLResponse | null` instead of a string, ensuring compatibility with the new response structure. [[1]](diffhunk://#diff-4dc5c01e24d77bc3ee3bda1d75be35b89bc8abddd2bf87c2c6cbfb7784e0ba5eL1-R12) [[2]](diffhunk://#diff-4dc5c01e24d77bc3ee3bda1d75be35b89bc8abddd2bf87c2c6cbfb7784e0ba5eL24-R24)