### PR TITLE
add RequestStatusIndicator component for response status display

### DIFF
--- a/src/components/response-viewer/components/request-status-indicator/index.tsx
+++ b/src/components/response-viewer/components/request-status-indicator/index.tsx
@@ -1,0 +1,68 @@
+import { Badge } from '@/components/ui/badge'
+import { GraphQLResponse } from '@/generated/typeshare-types'
+import { cn } from '@/lib/utils'
+import { CheckCircle, Clock, XCircle } from 'lucide-react'
+
+interface RequestStatusIndicatorProps {
+  response: GraphQLResponse | null
+  isLoading?: boolean
+}
+
+export function RequestStatusIndicator(props: RequestStatusIndicatorProps) {
+  const { response, isLoading = false } = props
+
+  if (isLoading) {
+    return (
+      <div className="flex items-center gap-2 text-sm text-muted-foreground">
+        <Clock className="h-4 w-4 animate-spin" />
+        <span>Sending...</span>
+      </div>
+    )
+  }
+
+  if (!response) {
+    return null
+  }
+
+  const isSuccess = response.statusCode >= 200 && response.statusCode < 300
+  const isClientError = response.statusCode >= 400 && response.statusCode < 500
+  const isServerError = response.statusCode >= 500
+
+  const formatDuration = (ms: number) => {
+    if (ms < 1000) {
+      return `${ms}ms`
+    } else if (ms < 60000) {
+      return `${(ms / 1000).toFixed(1)}s`
+    } else {
+      return `${Math.floor(ms / 60000)}m ${Math.floor((ms % 60000) / 1000)}s`
+    }
+  }
+
+  return (
+    <div className="flex items-center gap-3">
+      {/* Status Badge */}
+      <Badge
+        variant={isSuccess ? 'default' : 'destructive'}
+        className={cn(
+          'flex items-center gap-1 text-xs',
+          isSuccess && 'bg-green-100 text-green-800 hover:bg-green-100',
+          isClientError && 'bg-yellow-100 text-yellow-800 hover:bg-yellow-100',
+          isServerError && 'bg-red-100 text-red-800 hover:bg-red-100'
+        )}
+      >
+        {isSuccess ? (
+          <CheckCircle className="h-3 w-3" />
+        ) : (
+          <XCircle className="h-3 w-3" />
+        )}
+        {response.statusCode}
+      </Badge>
+
+      {/* Duration */}
+      <div className="flex items-center gap-1 text-sm text-muted-foreground">
+        <Clock className="h-3 w-3" />
+        <span>{formatDuration(response.durationMs)}</span>
+      </div>
+    </div>
+  )
+}

--- a/src/components/response-viewer/index.tsx
+++ b/src/components/response-viewer/index.tsx
@@ -7,6 +7,7 @@ import {
 } from '@/components/ui/dropdown-menu'
 import { ChevronDown } from 'lucide-react'
 import { JsonViewer } from '../json-viewer'
+import { RequestStatusIndicator } from './components/request-status-indicator'
 import { ResponseViewType, viewLabels, ViewTypeMenuItems } from './constants'
 import { ResponseViewerProps, useResponseViewerService } from './use-service'
 
@@ -39,6 +40,7 @@ export function ResponseViewer(props: ResponseViewerProps) {
             ))}
           </DropdownMenuContent>
         </DropdownMenu>
+        <RequestStatusIndicator response={data} />
       </div>
 
       <div className="flex-1 overflow-auto">


### PR DESCRIPTION
Closes: #56 

This pull request introduces a new `RequestStatusIndicator` component to enhance the user interface by displaying the status and duration of GraphQL requests. The component is integrated into the `ResponseViewer` to provide real-time feedback on request status.

### New Feature: Request Status Indicator

* **`RequestStatusIndicator` Component**: A new component was added in `src/components/response-viewer/components/request-status-indicator/index.tsx` to display the status (success, client error, server error) and duration of GraphQL requests. It uses visual indicators like badges and icons for better user experience.

### Integration into Response Viewer

* **Import Statement Update**: The `RequestStatusIndicator` component was imported into `src/components/response-viewer/index.tsx` to make it available for use within the `ResponseViewer` component.
* **Component Integration**: The `RequestStatusIndicator` was integrated into the `ResponseViewer` to display the request status and duration alongside other response details.