### PR TITLE
add react-split for responsive layout in Explorer component

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "react-dom": "^19.1.0",
     "react-hook-form": "^7.57.0",
     "react-resizable-panels": "^3.0.2",
+    "react-split": "^2.0.14",
     "tailwind-merge": "^3.3.1",
     "tailwindcss": "^4.1.10",
     "tailwindcss-animate": "^1.0.7",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -116,6 +116,9 @@ importers:
       react-resizable-panels:
         specifier: ^3.0.2
         version: 3.0.2(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      react-split:
+        specifier: ^2.0.14
+        version: 2.0.14(react@19.1.0)
       tailwind-merge:
         specifier: ^3.3.1
         version: 3.3.1
@@ -3731,6 +3734,11 @@ packages:
       react: ^16.14.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc
       react-dom: ^16.14.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc
 
+  react-split@2.0.14:
+    resolution: {integrity: sha512-bKWydgMgaKTg/2JGQnaJPg51T6dmumTWZppFgEbbY0Fbme0F5TuatAScCLaqommbGQQf/ZT1zaejuPDriscISA==}
+    peerDependencies:
+      react: '*'
+
   react-style-singleton@2.2.3:
     resolution: {integrity: sha512-b6jSvxvVnyptAiLjbkWLE/lOnR4lfTtDAl+eUC7RZy+QQWc6wRzIV2CE6xBuMmDxc2qIihtDCZD5NPOFl7fRBQ==}
     engines: {node: '>=10'}
@@ -4000,6 +4008,9 @@ packages:
   spdy@4.0.2:
     resolution: {integrity: sha512-r46gZQZQV+Kl9oItvl1JZZqJKGr+oEkB08A6BzkiR7593/7IbtuncXHd2YoYeTsG4157ZssMu9KYvUHLcjcDoA==}
     engines: {node: '>=6.0.0'}
+
+  split.js@1.6.5:
+    resolution: {integrity: sha512-mPTnGCiS/RiuTNsVhCm9De9cCAUsrNFFviRbADdKiiV+Kk8HKp/0fWu7Kr8pi3/yBmsqLFHuXGT9UUZ+CNLwFw==}
 
   stackframe@1.3.4:
     resolution: {integrity: sha512-oeVtt7eWQS+Na6F//S4kJ2K2VbRlS9D43mAlMyVpVWovy9o+jfgH8O9agzANzaiLjclA0oYzUXEM4PurhSUChw==}
@@ -8220,6 +8231,12 @@ snapshots:
       react: 19.1.0
       react-dom: 19.1.0(react@19.1.0)
 
+  react-split@2.0.14(react@19.1.0):
+    dependencies:
+      prop-types: 15.8.1
+      react: 19.1.0
+      split.js: 1.6.5
+
   react-style-singleton@2.2.3(@types/react@19.1.8)(react@19.1.0):
     dependencies:
       get-nonce: 1.0.1
@@ -8564,6 +8581,8 @@ snapshots:
       spdy-transport: 3.0.0
     transitivePeerDependencies:
       - supports-color
+
+  split.js@1.6.5: {}
 
   stackframe@1.3.4: {}
 

--- a/src/query-box-app/explorer/index.tsx
+++ b/src/query-box-app/explorer/index.tsx
@@ -1,44 +1,40 @@
 import { ResponseViewer } from '@/components/response-viewer'
-import {
-  ResizableHandle,
-  ResizablePanel,
-  ResizablePanelGroup,
-} from '@/components/ui/resizable'
+import Split from 'react-split'
 import { Documentation } from './documentation'
 import { RequestHistoryTabs } from './history-tabs'
 import { Request } from './request'
-import { useExplorerService } from './use-explorer-sevice'
+import { splitComponentProps, useExplorerService } from './use-explorer-sevice'
 
 export function Explorer() {
   const service = useExplorerService()
+
   return (
-    <div className="explorer flex-1 flex flex-col">
-      <div className="flex-1 flex min-h-0">
-        <ResizablePanelGroup direction="horizontal">
-          <ResizablePanel defaultSize={30} minSize={30}>
-            <Documentation />
-          </ResizablePanel>
-          <ResizableHandle />
-          <ResizablePanel
-            defaultSize={70}
-            minSize={40}
-            className="flex flex-col"
+    <div className="explorer bg-white flex-1 flex flex-col">
+      <Split
+        className="flex-1 flex min-h-0"
+        {...splitComponentProps}
+        sizes={[30, 70]}
+      >
+        <div className=" p-4 h-full">
+          <Documentation />
+        </div>
+        <div className="flex flex-col pt-4 h-full">
+          <RequestHistoryTabs />
+
+          <Split
+            className="flex-1 flex min-h-0"
+            {...splitComponentProps}
+            sizes={[50, 50]}
           >
-            <RequestHistoryTabs />
-            <div className="flex-1 min-h-0">
-              <ResizablePanelGroup direction="horizontal">
-                <ResizablePanel defaultSize={50} minSize={20}>
-                  <Request />
-                </ResizablePanel>
-                <ResizableHandle />
-                <ResizablePanel defaultSize={50} minSize={20}>
-                  <ResponseViewer data={service.response} />
-                </ResizablePanel>
-              </ResizablePanelGroup>
+            <div className="pt-4 h-full">
+              <Request />
             </div>
-          </ResizablePanel>
-        </ResizablePanelGroup>
-      </div>
+            <div className="pt-4 h-full">
+              <ResponseViewer data={service.response} />
+            </div>
+          </Split>
+        </div>
+      </Split>
     </div>
   )
 }

--- a/src/query-box-app/explorer/use-explorer-sevice.ts
+++ b/src/query-box-app/explorer/use-explorer-sevice.ts
@@ -1,6 +1,25 @@
 import { useGraphQLExplorerPageStore } from '@/stores'
+import { SplitProps } from 'react-split'
 
 export const useExplorerService = () => {
   const { response } = useGraphQLExplorerPageStore()
+
   return { response }
+}
+
+const gutterStyle: Partial<CSSStyleDeclaration> = {
+  paddingLeft: '3px',
+  paddingRight: '3px',
+  boxSizing: 'content-box',
+  height: '100%',
+  cursor: 'col-resize',
+  background:
+    'linear-gradient(to right, transparent 3px, var(--border) 3px, var(--border) 4px, transparent 4px)',
+}
+
+export const splitComponentProps: SplitProps = {
+  direction: 'horizontal',
+  gutterSize: 8,
+  minSize: 300,
+  gutterStyle: () => gutterStyle,
 }


### PR DESCRIPTION
Closes: #58 
This pull request introduces the `react-split` library to replace the existing resizable panel implementation in the `Explorer` component. It updates dependencies, refactors the `Explorer` layout, and adds utility functions for configuring the `react-split` behavior.

### Component Refactoring:
* Replaced the custom `ResizablePanel` components in `src/query-box-app/explorer/index.tsx` with `react-split` for handling resizable layouts. This simplifies the layout structure and improves maintainability.

### Utility Enhancements:
* Added `splitComponentProps` in `src/query-box-app/explorer/use-explorer-sevice.ts` to centralize configuration for `react-split`, including gutter styles, direction, and minimum sizes. This improves reusability and consistency.
