### PR TITLE
disabled devServer overlay

### DIFF
--- a/webpack/config.dev.js
+++ b/webpack/config.dev.js
@@ -22,6 +22,9 @@ module.exports = {
   devServer: {
     port: 3000,
     hot: true,
+    client: {
+      overlay: false,
+    },
   },
   optimization: {
     splitChunks: {


### PR DESCRIPTION
Closes: #65 

This pull request makes a small configuration change to the Webpack development server. The change disables the error overlay in the browser by setting `overlay: false` in the `client` property of the `devServer` configuration.

* [`webpack/config.dev.js`](diffhunk://#diff-15456664033a3c9759e6c37645b98218ef8722b9764150c7b05d971bb340be42R25-R27): Added `client: { overlay: false }` to the `devServer` configuration to disable the error overlay in the browser.