### PR TITLE
enhance GraphQL request handling with structured payload and request with header

### DIFF
--- a/src/bridges/graphql-bridge.ts
+++ b/src/bridges/graphql-bridge.ts
@@ -1,10 +1,16 @@
-import { GraphQLResponse } from '@/generated/typeshare-types'
+import {
+  GraphQLResponse,
+  SendGraphQLRequestPayload,
+} from '@/generated/typeshare-types'
 import { invoke } from '@tauri-apps/api/core'
 
 export class GraphQLBridge {
-  static async send_graphql_request(data: { endpoint: string; query: string }) {
+  static async send_graphql_request(data: SendGraphQLRequestPayload) {
+    console.debug('Sending GraphQL request:', data)
     try {
-      return await invoke<GraphQLResponse>('send_graphql_request', data)
+      return await invoke<GraphQLResponse>('send_graphql_request', {
+        data,
+      })
     } catch (error) {
       console.error('Failed to send GraphQL request:', error)
       throw error

--- a/src/hooks/use-graphql-schema.ts
+++ b/src/hooks/use-graphql-schema.ts
@@ -87,7 +87,7 @@ export function useGraphQLSchema(data: {
       const attemptFetch = async (): Promise<void> => {
         try {
           const parsedSchema = await fetchGraphqlSchema({
-            endpointUrl: endpoint.url,
+            endpoint,
             timeout,
             signal: abortControllerRef.current?.signal,
           })

--- a/src/lib/graphql-schema.ts
+++ b/src/lib/graphql-schema.ts
@@ -1,3 +1,4 @@
+import { Endpoint } from '@/generated/typeshare-types'
 import {
   buildClientSchema,
   getIntrospectionQuery,
@@ -5,21 +6,22 @@ import {
   IntrospectionQuery,
 } from 'graphql'
 import { createGraphQLFetcher } from './fetch'
+import { formatHeadersStringToObject } from './request'
 
 export async function fetchGraphqlSchema(params: {
-  endpointUrl: string
+  endpoint: Endpoint
   timeout?: number // Request timeout in milliseconds
   signal?: AbortSignal
 }): Promise<GraphQLSchema> {
-  const { endpointUrl, timeout, signal } = params
+  const { endpoint, timeout, signal } = params
 
   const fetcher = createGraphQLFetcher({
-    url: endpointUrl,
+    url: endpoint.url,
     timeout,
     signal,
     headers: {
-      'Content-Type': 'application/json',
-      Accept: 'application/json',
+      'User-Agent': navigator.userAgent,
+      ...formatHeadersStringToObject(endpoint.headers),
     },
   })
 

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -1,3 +1,4 @@
 export * from './connectivity'
 export * from './fetch'
 export * from './graphql-schema'
+export * from './request'

--- a/src/lib/request.ts
+++ b/src/lib/request.ts
@@ -1,0 +1,24 @@
+export function formatHeadersStringToObject(
+  headers: string | undefined | null
+): Record<string, string> | undefined {
+  if (!headers) return
+  try {
+    const arr = JSON.parse(headers) as Array<{
+      id: string
+      key: string
+      value: string
+    }>
+    if (!Array.isArray(arr)) return
+    return arr.reduce(
+      (acc, item) => {
+        if (item.key) {
+          acc[item.key] = item.value
+        }
+        return acc
+      },
+      {} as Record<string, string>
+    )
+  } catch (e) {
+    console.error('Failed to parse headers string:', e)
+  }
+}

--- a/src/query-box-app/explorer/request/use-service.ts
+++ b/src/query-box-app/explorer/request/use-service.ts
@@ -1,5 +1,6 @@
 import { GraphQLBridge, RequestHistoryBridge } from '@/bridges'
 import { useGraphQLSchema } from '@/hooks'
+import { formatHeadersStringToObject } from '@/lib'
 import {
   useEndpointSelectedStateStore,
   useGraphQLExplorerPageStore,
@@ -84,6 +85,9 @@ export const useRequestService = () => {
     mutate({
       endpoint: currentPageSelectedEndpoint?.url ?? '',
       query: activeRequestHistory?.query ?? '',
+      headers: formatHeadersStringToObject(
+        currentPageSelectedEndpoint?.headers
+      ),
     })
   }
 


### PR DESCRIPTION
Closes: #60 

This pull request introduces significant improvements to the GraphQL request handling and related functionality. The main changes include refactoring the request payload structure, enhancing header handling, and updating the client-side code to align with these backend changes.

### Backend Changes

* **Refactored `send_graphql_request` payload structure**: Introduced a new `SendGraphQLRequestPayload` struct to encapsulate the GraphQL request parameters, replacing individual function arguments with a single structured parameter. This improves code readability and maintainability. (`src-tauri/src/commands/graphql_commands.rs`) [[1]](diffhunk://#diff-e9a31aa6d7836f128408b9f97e6246d8ed0b405d0d20df07ed057559dab5cc6cR31-R55) [[2]](diffhunk://#diff-e9a31aa6d7836f128408b9f97e6246d8ed0b405d0d20df07ed057559dab5cc6cL51-R78) [[3]](diffhunk://#diff-e9a31aa6d7836f128408b9f97e6246d8ed0b405d0d20df07ed057559dab5cc6cL68-R93)

* **Added default `User-Agent` header**: Updated the request construction to include a default `User-Agent` header ("Query box GraphQL Client") for better compatibility and debugging. (`src-tauri/src/commands/graphql_commands.rs`)

### Frontend Changes

* **Updated `GraphQLBridge` to use the new payload structure**: Modified the `send_graphql_request` method to use the `SendGraphQLRequestPayload` type, ensuring compatibility with the backend changes. Added debug logging for outgoing requests. (`src/bridges/graphql-bridge.ts`)

* **Enhanced header handling in schema fetching**: Replaced the `endpointUrl` parameter with a more structured `Endpoint` type in `fetchGraphqlSchema`. Added a utility to parse headers from a JSON string into an object for consistent header management. (`src/lib/graphql-schema.ts`, `src/lib/request.ts`) [[1]](diffhunk://#diff-a19074236b1e7fcc4f39e065301f8f001b15c424282ace287f586daa5632819dR1-R24) [[2]](diffhunk://#diff-be2aa914ed423e38b7149d4718b6c64db230de5422f37c141dc7549f1c09d9b6R1-R24)

* **Integrated header formatting utility**: Applied the `formatHeadersStringToObject` utility in the `useRequestService` hook to convert endpoint headers before making requests. (`src/query-box-app/explorer/request/use-service.ts`) [[1]](diffhunk://#diff-8f773a7477963be99781b7964c0cec5694b6dec9d0010fee5a54f491fd312367R3) [[2]](diffhunk://#diff-8f773a7477963be99781b7964c0cec5694b6dec9d0010fee5a54f491fd312367R88-R90)