### PR TITLE
fix: update migration path to use resource directory instead of nt directory

### DIFF
--- a/src-tauri/src/database/connection.rs
+++ b/src-tauri/src/database/connection.rs
@@ -32,8 +32,15 @@ pub async fn initialize_db(app_handle: &AppHandle) -> Result<(), Box<dyn std::er
 pub async fn run_migrations(app_handle: &AppHandle) -> Result<(), Box<dyn std::error::Error>> {
     let pool = app_handle.state::<SqlitePool>();
 
-    let current_dir = std::env::current_dir()?;
-    let migrations_path = current_dir.join("migrations");
+    let resource_dir = app_handle.path().resource_dir().or_else(|err| {
+        println!("Failed to get resource directory: {}", err);
+        Err(std::io::Error::new(
+            std::io::ErrorKind::NotFound,
+            "Resource directory not found",
+        ))
+    })?;
+
+    let migrations_path = resource_dir.join("migrations");
 
     if migrations_path.exists() {
         match sqlx::migrate::Migrator::new(migrations_path).await {


### PR DESCRIPTION
Closes: #72 

This pull request updates the database initialization logic to improve error handling and ensure compatibility with the application's resource directory structure.

Database initialization improvements:

* [`src-tauri/src/database/connection.rs`](diffhunk://#diff-80a0ea3573201a3f8a1a276c15524708d42ec0c84623c5293f95c221fff96fbbL35-R43): Replaced the use of `std::env::current_dir()` with `app_handle.path().resource_dir()` to determine the resource directory for migrations, and added error handling to log a message when the resource directory cannot be found.