### PR TITLE
78 history tab interaction optimization

### DIFF
--- a/src/query-box-app/explorer/history-tabs/index.tsx
+++ b/src/query-box-app/explorer/history-tabs/index.tsx
@@ -39,7 +39,10 @@ export function RequestHistoryTabs() {
                 variant="ghost"
                 size="icon"
                 className="flex items-center cursor-pointer w-5 h-5"
-                onClick={() => service.handleDeleteRequestHistory(record.id)}
+                onClick={(event) => {
+                  event.stopPropagation()
+                  service.handleDeleteRequestHistory(record.id)
+                }}
               >
                 <X />
                 <span className="sr-only">Close tab</span>

--- a/src/query-box-app/explorer/history-tabs/use-service.ts
+++ b/src/query-box-app/explorer/history-tabs/use-service.ts
@@ -81,9 +81,11 @@ export const useRequestHistoryTabsService = () => {
       return
     }
     setRequestHistories(newRequestHistories)
-    setActiveRequestHistory(
-      requestHistories[targetRequestHistoryIndex - 1] ?? null
-    )
+    if (activeRequestHistory?.id === id) {
+      const nextActiveRequestHistory =
+        newRequestHistories[Math.max(targetRequestHistoryIndex - 1, 0)]
+      setActiveRequestHistory(nextActiveRequestHistory)
+    }
   }
 
   const handleDeleteAllRequestHistories = async () => {


### PR DESCRIPTION
Closes: #78 

- commit-https://github.com/zhnd/query-box/commit/5fdadd02f3c184fe2e97358bef7c696fb59296e4: fix triggering tab click action when deleting a tab

- commit-https://github.com/zhnd/query-box/commit/afedad76052cd583adf7da03e11c97291d6eea46: fix the interaction logic for auto-selection when deleting a tab
