### PR TITLE
feat: reset dialog state when close

### DIFF
--- a/src/query-box-app/endpoint/create/index.tsx
+++ b/src/query-box-app/endpoint/create/index.tsx
@@ -30,7 +30,7 @@ export function CreateEndpoint(props: CreateEndpointProps) {
   return (
     <Dialog
       open={service.createDialogOpen}
-      onOpenChange={service.setCreateDialogOpen}
+      onOpenChange={service.handleSetCreateDialogOpen}
     >
       <DialogContent className="sm:max-w-md md:max-w-lg flex flex-col max-h-[85vh] overflow-auto">
         <DialogHeader>

--- a/src/query-box-app/endpoint/create/use-service.ts
+++ b/src/query-box-app/endpoint/create/use-service.ts
@@ -42,6 +42,15 @@ export const useCreateEndpointService = (props: CreateEndpointProps) => {
   )
   const queryClient = useQueryClient()
 
+  const form = useForm<FormValues>({
+    resolver: zodResolver(formSchema),
+    defaultValues: {
+      name: '',
+      url: '',
+      headers: [{ id: nanoid(), key: '', value: '' }],
+    },
+  })
+
   const setCreateDialogOpen = useEndpointPageStore(
     (state) => state.setCreateDialogOpen
   )
@@ -49,26 +58,24 @@ export const useCreateEndpointService = (props: CreateEndpointProps) => {
   const {
     loading: checkConnectivityLoading,
     result: checkConnectivityResult,
+    cancel: cancelCheckConnectivity,
     checkConnectivity,
   } = useEndpointConnectivity()
+
+  const resetState = () => {
+    cancelCheckConnectivity()
+    form.reset()
+  }
 
   const mutation = useMutation({
     mutationFn: EndpointBridge.createEndpoint,
     onSuccess: (data) => {
       queryClient.invalidateQueries({ queryKey: ['endpoints'] })
       setCreateDialogOpen(false)
+      resetState()
       onCreateSuccess?.({
         endpoint: data,
       })
-    },
-  })
-
-  const form = useForm<FormValues>({
-    resolver: zodResolver(formSchema),
-    defaultValues: {
-      name: '',
-      url: '',
-      headers: [{ id: nanoid(), key: '', value: '' }],
     },
   })
 
@@ -115,9 +122,16 @@ export const useCreateEndpointService = (props: CreateEndpointProps) => {
     )
   }
 
+  const handleSetCreateDialogOpen = (open: boolean) => {
+    setCreateDialogOpen(open)
+    if (!open) {
+      resetState()
+    }
+  }
+
   return {
     createDialogOpen,
-    setCreateDialogOpen,
+    handleSetCreateDialogOpen,
     checkConnectivityLoading,
     checkConnectivityResult,
     form,

--- a/src/query-box-app/endpoint/update/index.tsx
+++ b/src/query-box-app/endpoint/update/index.tsx
@@ -31,7 +31,7 @@ export function UpdateEndpoint(props: UpdateEndpointProps) {
   return (
     <Dialog
       open={service.updateDialogOpen}
-      onOpenChange={service.setUpdateDialogOpen}
+      onOpenChange={service.handleSetUpdateDialogOpen}
     >
       <DialogContent className="sm:max-w-md md:max-w-lg flex flex-col max-h-[85vh] overflow-auto">
         <DialogHeader>

--- a/src/query-box-app/endpoint/update/use-update-endpoint-service.ts
+++ b/src/query-box-app/endpoint/update/use-update-endpoint-service.ts
@@ -38,7 +38,7 @@ export const useUpdateEndpointService = (data: UpdateEndpointProps) => {
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['endpoints'] })
       setUpdateDialogOpen(false)
-      setOperateEndpoint(null)
+      resetState()
       onUpdateSuccess?.()
     },
     onError: (error: Error) => {
@@ -49,12 +49,18 @@ export const useUpdateEndpointService = (data: UpdateEndpointProps) => {
   const {
     loading: checkConnectivityLoading,
     result: checkConnectivityResult,
+    cancel: cancelCheckConnectivity,
     checkConnectivity,
   } = useEndpointConnectivity()
 
   const form = useForm<FormValues>({
     resolver: zodResolver(formSchema),
   })
+
+  const resetState = () => {
+    cancelCheckConnectivity()
+    setOperateEndpoint(null)
+  }
 
   useEffect(() => {
     const initialValues = getUpdateEndpointFormInitialValues({
@@ -105,9 +111,16 @@ export const useUpdateEndpointService = (data: UpdateEndpointProps) => {
     )
   }
 
+  const handleSetUpdateDialogOpen = (open: boolean) => {
+    setUpdateDialogOpen(open)
+    if (!open) {
+      resetState()
+    }
+  }
+
   return {
     updateDialogOpen,
-    setUpdateDialogOpen,
+    handleSetUpdateDialogOpen,
     checkConnectivityLoading,
     checkConnectivityResult,
     form,


### PR DESCRIPTION
closes: #86 

The dialog component in the radix component library does not have a "destroy on close" feature, requiring manual reset of its internal state.

https://ui.shadcn.com/docs/components/dialog