### PR TITLE
feat: refactor header handling in GraphQL requests

### DIFF
--- a/src/lib/graphql-schema.ts
+++ b/src/lib/graphql-schema.ts
@@ -5,6 +5,7 @@ import {
   getIntrospectionQuery,
   GraphQLSchema,
 } from 'graphql'
+import { getGraphQLRequestHeaders } from './request'
 
 export async function fetchGraphqlSchema(params: {
   endpoint: {
@@ -16,24 +17,17 @@ export async function fetchGraphqlSchema(params: {
 }): Promise<GraphQLSchema | null> {
   const { endpoint, isCheckConnectivity } = params
 
-  const customHeaders: Record<string, string> = {
-    'Content-Type': 'application/json',
-    Accept: 'application/json',
-    'User-Agent': navigator.userAgent,
-    ...endpoint.headers,
-  }
-
-  if (endpoint.auth) {
-    customHeaders['Authorization'] = `Basic ${btoa(
-      `${endpoint.auth?.username || ''}:${endpoint.auth?.password || ''}`
-    )}`
-  }
-
   try {
     const schemaResponse = await ProxyHttpBridge.proxy_http_request({
       url: endpoint.url,
       method: 'POST',
-      headers: customHeaders,
+      headers: getGraphQLRequestHeaders({
+        endpoint: {
+          url: endpoint.url,
+          auth: endpoint.auth,
+        },
+        customHeaders: endpoint.headers,
+      }),
       body: JSON.stringify({
         query: getIntrospectionQuery(),
         operationName: 'IntrospectionQuery',

--- a/src/lib/request.ts
+++ b/src/lib/request.ts
@@ -1,3 +1,5 @@
+import { Endpoint } from '@/generated/typeshare-types'
+
 export function formatHeadersStringToObject(
   headers: string | undefined | null
 ): Record<string, string> | undefined {
@@ -21,4 +23,28 @@ export function formatHeadersStringToObject(
   } catch (e) {
     console.error('Failed to parse headers string:', e)
   }
+}
+
+export function getGraphQLRequestHeaders(params: {
+  endpoint: Pick<Endpoint, 'url' | 'headers' | 'auth'> | undefined | null
+  customHeaders?: Record<string, string>
+}): Record<string, string> | undefined {
+  const { endpoint, customHeaders } = params
+
+  if (!endpoint) return
+
+  const defaultHeaders: Record<string, string> = {
+    'Content-Type': 'application/json',
+    Accept: 'application/json',
+    'User-Agent': navigator.userAgent,
+    ...formatHeadersStringToObject(endpoint.headers),
+  }
+
+  if (endpoint.auth) {
+    defaultHeaders['Authorization'] = `Basic ${btoa(
+      `${endpoint.auth?.username || ''}:${endpoint.auth?.password || ''}`
+    )}`
+  }
+
+  return { ...defaultHeaders, ...customHeaders }
 }

--- a/src/query-box-app/explorer/request/use-service.ts
+++ b/src/query-box-app/explorer/request/use-service.ts
@@ -1,6 +1,6 @@
 import { GraphQLBridge, RequestHistoryBridge } from '@/bridges'
 import { useGraphQLSchema } from '@/hooks'
-import { formatHeadersStringToObject } from '@/lib'
+import { getGraphQLRequestHeaders } from '@/lib'
 import {
   useEndpointSelectedStateStore,
   useGraphQLExplorerPageStore,
@@ -106,9 +106,9 @@ export const useRequestService = () => {
     mutate({
       endpoint: currentPageSelectedEndpoint?.url ?? '',
       query: activeRequestHistory?.query ?? '',
-      headers: formatHeadersStringToObject(
-        currentPageSelectedEndpoint?.headers
-      ),
+      headers: getGraphQLRequestHeaders({
+        endpoint: currentPageSelectedEndpoint,
+      }),
     })
   }
 


### PR DESCRIPTION
Closes: #91 

basic auth info should payload with GraphQL request.