### PR TITLE
fix: adjust padding in Create and Update Endpoint forms

### DIFF
--- a/src/query-box-app/endpoint/create/index.tsx
+++ b/src/query-box-app/endpoint/create/index.tsx
@@ -46,7 +46,7 @@ export function CreateEndpoint(props: CreateEndpointProps) {
             onSubmit={service.form.handleSubmit(service.onSubmit)}
             className="flex flex-col flex-1 min-h-0"
           >
-            <div className="flex-1 min-h-0 overflow-y-auto pr-2 -mr-2 space-y-4">
+            <div className="flex-1 min-h-0 overflow-y-auto px-2 -mx-2 space-y-4">
               <FormField
                 control={service.form.control}
                 name="name"

--- a/src/query-box-app/endpoint/update/index.tsx
+++ b/src/query-box-app/endpoint/update/index.tsx
@@ -47,7 +47,7 @@ export function UpdateEndpoint(props: UpdateEndpointProps) {
             onSubmit={service.form.handleSubmit(service.onSubmit)}
             className="flex flex-col flex-1 min-h-0"
           >
-            <div className="flex-1 min-h-0 overflow-y-auto pr-2 -mr-2 space-y-4">
+            <div className="flex-1 min-h-0 overflow-y-auto px-2 -mx-2 space-y-4">
               <FormField
                 control={service.form.control}
                 name="name"


### PR DESCRIPTION
Closes: #100 

modifies the padding and margin styles in the `CreateEndpoint` and `UpdateEndpoint` components to improve layout consistency.